### PR TITLE
Update file references after serverless-tests move

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ requestHeaders:
 
 ## Example configuration
 
-Please view the example [serverless.yml](test/serverless\ 2/serverless.yml).
+Please view the example [serverless.yml](test/serverless-tests/serverless%202/serverless.yml).
 
 ## Notes on schemas
 

--- a/test/serverless-tests/inferred/serverless.yml
+++ b/test/serverless-tests/inferred/serverless.yml
@@ -5,7 +5,7 @@ provider:
   runtime: nodejs14.x
 
 plugins:
-  - ../../index.js
+  - ../../../index.js
 
 functions:
   updateUser:

--- a/test/serverless-tests/serverless 1/serverless.yml
+++ b/test/serverless-tests/serverless 1/serverless.yml
@@ -6,7 +6,7 @@ provider:
   runtime: nodejs14.x
 
 plugins:
-  - ../../index.js
+  - ../../../index.js
 
 functions:
   createUser:
@@ -59,12 +59,12 @@ custom:
       - name: ErrorResponse
         description: This is an error
         contentType: application/json
-        schema: ${file(models/ErrorResponse.json)}
+        schema: ${file(../../models/ErrorResponse.json)}
 
       - name: PutDocumentResponse
         description: PUT Document response model (external reference example)
         contentType: application/json
-        schema: ${file(models/PutDocumentResponse.json)}
+        schema: ${file(../../models/PutDocumentResponse.json)}
 
       - name: PutDocumentRequest
         description: PUT Document request model (inline example)

--- a/test/serverless-tests/serverless 2/serverless.yml
+++ b/test/serverless-tests/serverless 2/serverless.yml
@@ -5,7 +5,7 @@ provider:
   runtime: nodejs14.x
 
 plugins:
-  - ../../index.js
+  - ../../../index.js
 
 functions:
   createUser:
@@ -99,13 +99,13 @@ custom:
         description: This is an error
         content:
           application/json:
-            schema: ${file(../models/ErrorResponse.json)}
+            schema: ${file(../../models/ErrorResponse.json)}
 
       - name: PutDocumentResponse
         description: PUT Document response model (external reference example)
         content:
           application/json:
-            schema: ${file(../models/PutDocumentResponse.json)}
+            schema: ${file(../../models/PutDocumentResponse.json)}
 
       - name: PutDocumentRequest
         description: PUT Document request model (inline example)

--- a/test/serverless-tests/serverless 3/serverless.yml
+++ b/test/serverless-tests/serverless 3/serverless.yml
@@ -5,7 +5,7 @@ provider:
   runtime: nodejs14.x
 
 plugins:
-  - ../../index.js
+  - ../../../index.js
 
 functions:
   createUser:
@@ -66,13 +66,13 @@ custom:
         description: This is an error
         content:
           application/json:
-            schema: ${file(../models/ErrorResponse.json)}
+            schema: ${file(../../models/ErrorResponse.json)}
 
       - name: PutDocumentResponse
         description: PUT Document response model (external reference example)
         content:
           application/json:
-            schema: ${file(../models/PutDocumentResponse.json)}
+            schema: ${file(../../models/PutDocumentResponse.json)}
 
       - name: PutDocumentRequest
         description: PUT Document request model (inline example)

--- a/test/serverless-tests/serverless httpApi/serverless.yml
+++ b/test/serverless-tests/serverless httpApi/serverless.yml
@@ -5,7 +5,7 @@ provider:
   runtime: nodejs14.x
 
 plugins:
-  - ../../index.js
+  - ../../../index.js
 
 functions:
   updateUser:
@@ -117,13 +117,13 @@ custom:
         description: This is an error
         content:
           application/json:
-            schema: ${file(../models/ErrorResponse.json)}
+            schema: ${file(../../models/ErrorResponse.json)}
 
       - name: PutDocumentResponse
         description: PUT Document response model (external reference example)
         content:
           application/json:
-            schema: ${file(../models/PutDocumentResponse.json)}
+            schema: ${file(../../models/PutDocumentResponse.json)}
 
       - name: PutDocumentRequest
         description: PUT Document request model (inline example)


### PR DESCRIPTION
Hi!

I noticed the file links in the tests and the link in the readme weren't updated in the move in #38 .

This should sort that!
I only tested generating an openapi files in the `serverless 2` and `serverless 3` folders, but the other changes should be ok too.