### PR TITLE
Correctly deal with poorly dereferenced schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-openapi-documenter",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-openapi-documenter",
-      "version": "0.0.43",
+      "version": "0.0.44",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-documenter",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "Generate OpenAPI v3 documentation and Postman Collections from your Serverless Config",
   "main": "index.js",
   "keywords": [

--- a/src/definitionGenerator.js
+++ b/src/definitionGenerator.js
@@ -479,8 +479,10 @@ class DefinitionGenerator {
             const path = oldRef.split('/')
 
             const pathTitle = path[path.length-1]
-            const property = deReferencedSchema.definitions[path[path.length-1]]
-            Object.assign(deReferencedSchema, {properties: {[pathTitle]: property}})
+            const referencedProperties = deReferencedSchema.definitions[pathTitle]
+
+            Object.assign(deReferencedSchema, {...referencedProperties})
+
             delete deReferencedSchema.$ref
             deReferencedSchema = await this.dereferenceSchema(deReferencedSchema)
                 .catch((err) => {

--- a/test/unit/definitionGenerator.spec.js
+++ b/test/unit/definitionGenerator.spec.js
@@ -887,9 +887,52 @@ describe('DefinitionGenerator', () => {
                     })
 
                 expect(definitionGenerator.openAPI.components.schemas).to.have.property('main')
-                expect(definitionGenerator.openAPI.components.schemas.main.properties).to.have.property('Error')
-                expect(definitionGenerator.openAPI.components.schemas.main.properties.Error).to.have.property('type')
-                expect(definitionGenerator.openAPI.components.schemas.main.properties.Error.type).to.be.equal('string')
+                expect(definitionGenerator.openAPI.components.schemas.main).to.have.property('type')
+                expect(definitionGenerator.openAPI.components.schemas.main.type).to.be.equal('string')
+                expect(definitionGenerator.openAPI.components.schemas.main).to.not.have.property('$schema')
+                expect(definitionGenerator.openAPI.components.schemas.main).to.not.have.property('$definitions')
+                expect(expected).to.equal('#/components/schemas/main')
+
+                expect(spy.callCount).to.be.equal(2)
+
+                spy.resetHistory()
+            });
+
+            it('should handle a complex schema that has been incorrectly dereferenced', async function() {
+                const definitionGenerator = new DefinitionGenerator(mockServerless)
+
+                const complexSchema = {
+                    $schema: 'http://json-schema.org/draft-04/schema#',
+                    title: 'JSON API Schema',
+                    $ref: '#/definitions/Person',
+                    definitions: {
+                        Person: {
+                            type: 'object',
+                            properties: {
+                                name: {
+                                    type: 'string'
+                                },
+                                age: {
+                                    type: 'number'
+                                }
+                            }
+                        }
+                    }
+                }
+
+                const spy = sinon.spy(definitionGenerator, 'dereferenceSchema')
+
+                const expected = await definitionGenerator.schemaCreator(complexSchema, 'main')
+                    .catch((err) => {
+                        console.error(err)
+                    })
+
+                expect(definitionGenerator.openAPI.components.schemas).to.have.property('main')
+                expect(definitionGenerator.openAPI.components.schemas.main).to.have.property('type')
+                expect(definitionGenerator.openAPI.components.schemas.main.type).to.be.equal('object')
+                expect(definitionGenerator.openAPI.components.schemas.main).to.have.property('properties')
+                expect(definitionGenerator.openAPI.components.schemas.main.properties).to.have.property('name')
+                expect(definitionGenerator.openAPI.components.schemas.main.properties).to.have.property('age')
                 expect(definitionGenerator.openAPI.components.schemas.main).to.not.have.property('$schema')
                 expect(definitionGenerator.openAPI.components.schemas.main).to.not.have.property('$definitions')
                 expect(expected).to.equal('#/components/schemas/main')
@@ -1052,9 +1095,8 @@ describe('DefinitionGenerator', () => {
                     })
 
                 expect(definitionGenerator.openAPI.components.schemas).to.have.property('LicensedMember')
-                expect(definitionGenerator.openAPI.components.schemas.LicensedMember.properties).to.have.property('Error')
-                expect(definitionGenerator.openAPI.components.schemas.LicensedMember.properties.Error).to.have.property('type')
-                expect(definitionGenerator.openAPI.components.schemas.LicensedMember.properties.Error.type).to.be.equal('string')
+                expect(definitionGenerator.openAPI.components.schemas.LicensedMember).to.have.property('type')
+                expect(definitionGenerator.openAPI.components.schemas.LicensedMember.type).to.be.equal('string')
                 expect(definitionGenerator.openAPI.components.schemas.LicensedMember).to.not.have.property('$schema')
                 expect(definitionGenerator.openAPI.components.schemas.LicensedMember).to.not.have.property('$definitions')
                 expect(expected).to.equal('#/components/schemas/LicensedMember')


### PR DESCRIPTION
This isa. fix for poorly dereferenced schemas where we need to pull the referenced schema into the main body of the new dereferenced schema.  Closes #85 