### PR TITLE
Correctly deal with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,12 +295,22 @@ custom:
         contentType: "application/json"
         schema:
           $schema: "http://json-schema.org/draft-04/schema#"
+          type: object
           properties:
             SomeObject:
               type: "object"
               properties:
                 SomeAttribute:
                   type: "string"
+        examples:
+          - name: someObjectInlineExample
+            summary: an example of a request
+            description: a longer string than the summary
+            value: {SomeObject: {SomeAttribute: 'attribute'}}
+          - name: someObjectExternalExample
+            summary: an example of a request external
+            description: a longer string than the summary
+            externalValue: https://example.com/external.json
 ```
 
 The Second way of writing the models:
@@ -329,12 +339,22 @@ custom:
           application/json:
             schema:
               $schema: "http://json-schema.org/draft-04/schema#"
+              type: object
               properties:
                 SomeObject:
                   type: "object"
                   properties:
                     SomeAttribute:
                       type: "string"
+            examples:
+              - name: someObjectInlineExample
+                summary: an example of a request
+                description: a longer string than the summary
+                value: {SomeObject: {SomeAttribute: 'attribute'}}
+              - name: someObjectExternalExample
+                summary: an example of a request external
+                description: a longer string than the summary
+                externalValue: https://example.com/external.json
 ```
 
 ##### Model re-use

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-openapi-documenter",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-openapi-documenter",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-documenter",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "Generate OpenAPI v3 documentation and Postman Collections from your Serverless Config",
   "main": "index.js",
   "keywords": [

--- a/src/definitionGenerator.js
+++ b/src/definitionGenerator.js
@@ -458,16 +458,22 @@ class DefinitionGenerator {
                 }
                 const obj = {}
 
-                if (mediaTypeDocumentation.example)
-                    obj.example = mediaTypeDocumentation.example
-
-                if (mediaTypeDocumentation.examples)
-                    obj.examples = this.createExamples(mediaTypeDocumentation.examples)
-
                 let schema
                 if (mediaTypeDocumentation?.content) {
+                    if (mediaTypeDocumentation.content[contentKey]?.example)
+                        obj.example = mediaTypeDocumentation.content[contentKey].example
+
+                    if (mediaTypeDocumentation.content[contentKey]?.examples)
+                        obj.examples = this.createExamples(mediaTypeDocumentation.content[contentKey].examples)
+
                     schema = mediaTypeDocumentation.content[contentKey].schema
                 } else if (mediaTypeDocumentation?.contentType && mediaTypeDocumentation.schema) {
+                    if (mediaTypeDocumentation?.example)
+                        obj.example = mediaTypeDocumentation.example
+
+                    if (mediaTypeDocumentation?.examples)
+                        obj.examples = this.createExamples(mediaTypeDocumentation.examples)
+
                     schema = mediaTypeDocumentation.schema
                 }
 
@@ -748,6 +754,7 @@ class DefinitionGenerator {
 
         for(const example of examples) {
             Object.assign(examplesObj, {[example.name]: example})
+            delete examplesObj[example.name].name
         }
 
         return examplesObj;

--- a/test/serverless-tests/serverless 3/serverless.yml
+++ b/test/serverless-tests/serverless 3/serverless.yml
@@ -95,3 +95,12 @@ custom:
                   properties:
                     SomeAttribute:
                       type: string
+            examples:
+              - name: someObjectInlineExample
+                summary: an example of a request
+                description: a longer string than the summary
+                value: {SomeObject: {SomeAttribute: 'attribute'}}
+              - name: someObjectExternalExample
+                summary: an example of a request external
+                description: a longer string than the summary
+                externalValue: https://example.com/external.json


### PR DESCRIPTION
This is a breaking change to how `examples` and `example` on models worked before.  It is for the better though.