### PR TITLE
Updating to apply requestBody.required if it is set

### DIFF
--- a/src/definitionGenerator.js
+++ b/src/definitionGenerator.js
@@ -348,7 +348,8 @@ class DefinitionGenerator {
                     requestModel,
                     {
                         description: documentation.requestBody.description,
-                        models: documentation.requestModels
+                        models: documentation.requestModels,
+                        required: documentation.requestBody.required
                     }
                 )
             } else {
@@ -511,7 +512,7 @@ class DefinitionGenerator {
     async createRequestBody(requestBodyDetails) {
         const obj = {
             description: requestBodyDetails.description,
-            required: false
+            required: requestBodyDetails.required || false
         }
 
         obj.content = await this.createMediaTypeObject(requestBodyDetails.models)


### PR DESCRIPTION
I noticed that when I set the required option under requestBody it wasn't getting picked up. So have submitted some changes to change it to pick up the required option if it is specified, otherwise it will be set to false. Originally it had been hardcoded to false.