### PR TITLE
Add x-code-samples field to endpoint definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Options:
 | path[path]                                                | functions.functions.events.[http OR httpApi].path                                                                                                     |
 | path[path].servers[].description                          | functions.functions.servers.description                                                                                                               |
 | path[path].servers[].url                                  | functions.functions.servers.url                                                                                                                       |
+| path[path].x-code-samples[].lang                          | functions.functions.x-code-samples.lang                                                                                              |
+| path[path].x-code-samples[].label                         | functions.functions.x-code-samples.label                                                                                             |
+| path[path].x-code-samples[].source                        | functions.functions.x-code-samples.source                                                                                            |
 | path[path].[operation]                                    | functions.functions.[http OR httpApi].method                                                                                                          |
 | path[path].[operation].summary                            | functions.functions.[http OR httpApi].documentation.summary                                                                                           |
 | path[path].[operation].description                        | functions.functions.[http OR httpApi].documentation.description                                                                                       |

--- a/src/definitionGenerator.js
+++ b/src/definitionGenerator.js
@@ -253,6 +253,32 @@ class DefinitionGenerator {
     return newServers;
   }
 
+  createXCodeSamples(xCodeSamples) {
+    const newXCodeSamples = [];
+
+    for (const xCodeSample of xCodeSamples) {
+      const obj = {
+        name: xCodeSample.name,
+      };
+
+      if (xCodeSample.lang) {
+        obj.lang = xCodeSample.lang;
+      }
+
+      if (xCodeSample.label) {
+        obj.label = xCodeSample.label;
+      }
+
+      if (xCodeSample.source) {
+        obj.source = xCodeSample.source;
+      }
+
+      newXCodeSamples.push(obj);
+    }
+    
+    return newXCodeSamples;
+  }
+
   createExternalDocumentation(docs) {
     return { ...docs };
     // const documentation = this.serverless.service.custom.documentation
@@ -417,6 +443,11 @@ class DefinitionGenerator {
     if (documentation.servers) {
       const servers = this.createServers(documentation.servers);
       obj.servers = servers;
+    }
+
+    if (documentation['x-code-samples']) {
+      const xCodeSamples  = this.createXCodeSamples(documentation['x-code-samples']);
+      obj['x-code-samples'] = xCodeSamples;
     }
 
     return { [method.toLowerCase()]: obj };

--- a/src/openAPIGenerator.js
+++ b/src/openAPIGenerator.js
@@ -116,6 +116,7 @@ class OpenAPIGenerator {
       properties: {
         summary: { type: "string" },
         servers: { anyOf: [{ type: "object" }, { type: "array" }] },
+        ['x-code-samples']: { type: "array" },
       },
     });
   }


### PR DESCRIPTION
Use **x-code-samples** field to add custom code samples in one or more languages to your operations.