### PR TITLE
Infer API details without requiring documentation objects.

### DIFF
--- a/src/definitionGenerator.js
+++ b/src/definitionGenerator.js
@@ -207,6 +207,7 @@ class DefinitionGenerator {
           this.currentEvent = event?.http || event?.httpApi;
           const documentation =
             (event?.http?.documentation || event?.httpApi?.documentation) || {};
+          documentation.description = documentation.description || httpFunction.functionInfo.description;
 
           this.currentFunctionName = httpFunction.functionInfo.name;
           this.operationName = httpFunction.operationName;

--- a/src/schemaHandler.js
+++ b/src/schemaHandler.js
@@ -11,7 +11,7 @@ class SchemaHandler {
   constructor(serverless, openAPI) {
     this.apiGatewayModels =
       serverless.service?.provider?.apiGateway?.request?.schemas || {};
-    this.documentation = serverless.service.custom.documentation;
+    this.documentation = serverless.service.custom?.documentation;
     this.openAPI = openAPI;
 
     this.modelReferences = {};
@@ -62,7 +62,7 @@ class SchemaHandler {
     for (const model of this.models) {
       const modelName = model.name;
       const modelSchema = model.schema;
-
+      
       const dereferencedSchema = await this.__dereferenceSchema(
         modelSchema
       ).catch((err) => {

--- a/test/serverless-tests/inferred/package.json
+++ b/test/serverless-tests/inferred/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "generate": "npx serverless openapi generate -o openapi.json -f json -a 3.0.3"
   },
   "keywords": [],
   "author": "",

--- a/test/serverless-tests/inferred/serverless.yml
+++ b/test/serverless-tests/inferred/serverless.yml
@@ -12,26 +12,18 @@ functions:
     handler: handler.update
     events:
       - httpApi:
-          path: 'PUT /update'
+          method: 'PUT'
+          path: '/update/{id}'
           cors: true
 
   createUser:
     handler: handler.create
     events:
-      - httpApi:
-          path: 'POST /create/{id}'
+      - http:
+          method: 'POST'
+          path: '/create/{id}'
+          request:
+            parameters:
+              paths:
+                id: false
           cors: true
-
-  # createUser:
-  #   handler: handler.create
-  #   events:
-  #     - httpApi:
-  #         path: /create
-  #         method: '*'
-  #         cors: true
-
-  # createUser:
-  #   handler: handler.create
-  #   events:
-  #     - httpApi: '*'
-

--- a/test/serverless-tests/inferred/serverless.yml
+++ b/test/serverless-tests/inferred/serverless.yml
@@ -18,6 +18,7 @@ functions:
 
   createUser:
     handler: handler.create
+    description: Creates a user
     events:
       - http:
           method: 'POST'

--- a/test/serverless-tests/serverless httpApi/package.json
+++ b/test/serverless-tests/serverless httpApi/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "generate": "npx serverless openapi generate -o openapi.json -f json -a 3.0.3"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
We have many projects with existing API definitions in serverless.yml. I want to generate openapi.json files without needing to document all these projects. In this PR API paths and parameters are inferred as well as using the function description.
It can also determine if path parameters are required.