### PR TITLE
fix: update OWASP data source to use raw GitHub URL (issue #275)

### DIFF
--- a/src/owasp.js
+++ b/src/owasp.js
@@ -95,7 +95,7 @@ class OWASP {
     const headerJSON = await new Promise((resolve, reject) => {
       const req = https
         .get(
-          "https://owasp.org/www-project-secure-headers/ci/headers_add.json",
+          "https://raw.githubusercontent.com/OWASP/www-project-secure-headers/refs/heads/master/ci/headers_add.json",
           (res) => {
             let data = [];
 

--- a/test/unit/owasp.spec.js
+++ b/test/unit/owasp.spec.js
@@ -11,8 +11,8 @@ const newOWASPJSON = require("../json/newOWASP.json");
 describe(`owasp`, function () {
   describe(`getLatest`, function () {
     it(`populates the defaults from the included OWASP release when the online version can not be reached`, async function () {
-      nock("https://owasp.org")
-        .get("/www-project-secure-headers/ci/headers_add.json")
+      nock("https://raw.githubusercontent.com")
+        .get("/OWASP/www-project-secure-headers/refs/heads/master/ci/headers_add.json")
         .reply(404, {});
 
       await owasp.getLatest().catch((err) => {
@@ -33,8 +33,8 @@ describe(`owasp`, function () {
     });
 
     it(`populates the defaults with information from a new OWASP release`, async function () {
-      nock("https://owasp.org")
-        .get("/www-project-secure-headers/ci/headers_add.json")
+      nock("https://raw.githubusercontent.com")
+        .get("/OWASP/www-project-secure-headers/refs/heads/master/ci/headers_add.json")
         .reply(200, newOWASPJSON);
 
       await owasp.getLatest().catch((err) => {
@@ -59,8 +59,8 @@ describe(`owasp`, function () {
       const newOWASPJSONAdded = structuredClone(newOWASPJSON);
       newOWASPJSONAdded.headers.push({ name: "x-added", value: "true" });
 
-      nock("https://owasp.org")
-        .get("/www-project-secure-headers/ci/headers_add.json")
+      nock("https://raw.githubusercontent.com")
+        .get("/OWASP/www-project-secure-headers/refs/heads/master/ci/headers_add.json")
         .reply(200, newOWASPJSONAdded);
 
       await owasp.getLatest().catch((err) => {


### PR DESCRIPTION
### Summary
Currently there is an error to generate the openapi spec file [ISSUE](https://github.com/JaredCE/serverless-openapi-documenter/issues/275) . This PR updates the OWASP secure-headers data source to fetch `headers_add.json` directly from GitHub's raw content host instead of `owasp.org`. It seems owasp moved the project files to github.

I believe request the github raw file is ok in the meantime, because the max rate limit is like 5k per source IP. Other option is use the api, but i believe will add complexity. 

<img width="928" height="280" alt="image" src="https://github.com/user-attachments/assets/5ffdd22e-fc9e-4b49-9cd5-67bb083b6dba" />

<img width="1127" height="456" alt="image" src="https://github.com/user-attachments/assets/ebfc788a-33a0-429c-b1c0-ee4733ee08e3" />

### Changes
- **`src/owasp.js`**: Changed the fetch URL from `https://owasp.org/www-project-secure-headers/ci/headers_add.json` to `https://raw.githubusercontent.com/OWASP/www-project-secure-headers/refs/heads/master/ci/headers_add.json`.
- **`test/unit/owasp.spec.js`**: Updated the `nock` HTTP mocks across all three `getLatest` test cases to match the new host and path.

### Why
The `owasp.org` endpoint no longer reliably serves the headers JSON. Pulling directly from the project's GitHub repo (`master` branch) provides a stable, canonical source for the latest secure-header definitions.

### Testing
- Existing unit tests in `test/unit/owasp.spec.js` updated and passing, covering:
  - Fallback to bundled defaults when the source is unreachable (404)
  - Populating defaults from a new OWASP release
  - Handling newly added headers in a release
